### PR TITLE
feat: 题目级收藏/标记按钮 + 修复 store 语义与 sidebar 紫条 bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,50 @@
 # Political Exam Practice System
 
-一个基于 Vue.js 2 的政治理论课刷题与模拟考试系统。旨在帮助学生高效复习各类政治理论课程，支持多种题型练习、模拟考试、错题回顾以及 AI 辅助学习。
+一个基于 Vue 3 + Vite 的政治理论课刷题与模拟考试系统。旨在帮助学生高效复习各类政治理论课程，支持多种题型练习、模拟考试、错题回顾、收藏/标记，以及 AI 辅助学习。项目同时内置了**全国计算机等级考试三级**题库模块。
 
 ## ✨ 主要功能 (Features)
 
-- **多科目支持**：涵盖马原、毛概、思修、史纲、形势与政策等多个政治理论科目。
+- **多科目支持**：涵盖马原、毛概、思修（思想道德与法治）、史纲、习概、改开史、新中国史、党史、社主史等多个政治理论科目。
 - **全题型覆盖**：
   - 单选题 (Single Choice)
   - 多选题 (Multiple Choice)
   - 判断题 (True/False)
   - 填空题 (Fill in the Blank)
 - **模拟考试 (Mock Exam)**：
-  - 随机组卷或指定章节练习
+  - 按试卷或章节练习
   - 自动评分与答题解析
+  - 错题自动归入错题本
 - **个性化学习**：
   - **错题本 (Wrong Questions)**：自动记录做错的题目，方便查漏补缺。
-  - **收藏夹 (Favorites)**：重点题目一键收藏。
-  - **学习记录 (User Records)**：统计做题情况和正确率。
+  - **收藏夹 (Favorites)**：题目右上角一键收藏 / 取消收藏，状态持久化到本地。
+  - **标记 (Marks)**：与收藏并列的标记按钮，用于额外标注重点题；同样持久化。
+  - **学习记录 (User Records)**：统计做题次数、错题次数与最近错题日期。
+- **NCRE 三级题库**：独立模块（`/ncre3`），覆盖三级网络技术 / 数据库技术等题型，并支持基于 mermaid 的 UML 图渲染。
 - **实用工具**：
-  - **PDF 导出**：支持将试题导出为 PDF 文件，方便打印复习。
-  - **AI 助手**：内置 Gemma AI 对话功能，辅助解答疑惑。
-- **现代化界面**：提供全新的移动端友好界面 (`/newHome`)，交互流畅。
+  - **PDF 导出**：支持将试题列表导出为 PDF 或直接打印。
+  - **AI 助手 (Beta)**：内置对话页面，辅助解答疑惑。
+- **现代化界面**：紫色调主题、侧边栏导航、Element Plus 组件库，桌面端体验为主。
 
 ## 🛠 技术栈 (Tech Stack)
 
-- **核心框架**: [Vue.js 2.x](https://v2.vuejs.org/)
-- **状态管理**: [Vuex](https://vuex.vuejs.org/) (配合 `vuex-persistedstate` 实现数据持久化)
-- **路由管理**: [Vue Router](https://router.vuejs.org/)
-- **UI 组件库**:
-  - [Vant UI](https://vant-ui.github.io/vant/v2/) (移动端/新版界面)
-  - [Element UI](https://element.eleme.io/) (桌面端/通用组件)
+- **核心框架**: [Vue 3](https://vuejs.org/)（Composition + Options 混合使用）
+- **构建工具**: [Vite 5](https://vitejs.dev/)
+- **状态管理**: [Pinia 2](https://pinia.vuejs.org/)，配合 [`pinia-plugin-persistedstate`](https://prazdevs.github.io/pinia-plugin-persistedstate/) 写入 `localStorage` 实现持久化
+- **路由管理**: [Vue Router 4](https://router.vuejs.org/)
+- **UI 组件库**: [Element Plus](https://element-plus.org/) + [@element-plus/icons-vue](https://element-plus.org/en-US/component/icon.html)
+- **样式**: SCSS（`sass`）
 - **工具库**:
-  - [Axios](https://axios-http.com/): HTTP 请求
-  - [Fuse.js](https://www.fusejs.io/): 模糊搜索支持
-  - [pdfmake](http://pdfmake.org/): PDF 生成
-  - [Less](http://lesscss.org/): CSS 预处理器
+  - [Axios](https://axios-http.com/)：HTTP 请求
+  - [Fuse.js](https://www.fusejs.io/)：模糊搜索
+  - [pdfmake](http://pdfmake.org/)：PDF 生成
+  - [marked](https://marked.js.org/) + [highlight.js](https://highlightjs.org/)：Markdown / 代码高亮
+  - [mermaid](https://mermaid.js.org/)：UML / 流程图渲染（NCRE3 模块用）
 
 ## 🚀 快速开始 (Getting Started)
 
 ### 环境要求
-- Node.js (推荐 LTS 版本)
-- npm 或 pnpm
+- Node.js（推荐 LTS，≥ 18）
+- pnpm（推荐）或 npm
 
 ### 安装步骤
 
@@ -52,37 +56,54 @@
 
 2. **安装依赖**
    ```bash
-   npm install
-   # 或者
    pnpm install
+   # 或者
+   npm install
    ```
 
-3. **运行开发服务器**
+3. **启动开发服务器**
    ```bash
-   npm run serve
+   pnpm dev
+   # 或者
+   npm run dev
    ```
-   启动后访问 `http://localhost:8080` (端口可能根据占用情况变化)。
+   默认运行在 `http://localhost:5173/`。可通过 `pnpm dev --port 8080` 自定义端口。
 
 4. **构建生产版本**
    ```bash
-   npm run build
+   pnpm build
    ```
+   产物输出到 `dist/`。可用 `pnpm preview` 在本地预览。
 
 ## 📂 项目结构 (Project Structure)
 
 ```
 src/
-├── assets/          # 静态资源（题目JSON数据、图片、图标）
-├── components/      # 公共组件 (ExamCard, QuestionCard, Gemma等)
-├── router/          # 路由配置
-├── store/           # Vuex 状态管理 (题库、错题、收藏、成绩)
-├── utils/           # 工具函数 (PDF生成, 试卷生成器等)
-├── views/           # 页面视图
-│   ├── new/         # 新版UI页面 (Home, Exam, Chat, etc.)
-│   └── ...          # 旧版/通用视图
-├── App.vue          # 根组件
-└── main.js          # 入口文件
+├── assets/           # 静态资源（题库 JSON、图片、SVG 图标）
+├── components/       # 公共组件 (questionCard, examCard, examRecord 等)
+├── router/           # 路由配置（包含 / / /newHome / /ncre3 三套入口）
+├── stores/           # Pinia 状态管理
+│   ├── question.js   # 题库 / 答题 / 错题 / 收藏 / 标记 / 学习记录
+│   └── ncre3.js      # NCRE3 题库状态
+├── utils/            # 工具函数（PDF 生成、题目加载、Markdown 渲染等）
+├── views/            # 页面视图
+│   ├── new/          # 主入口 UI（/newHome 路径下）
+│   ├── ncre3/        # NCRE 三级题库 UI
+│   └── ...           # 旧版表格化视图（/rightWrong、/multipleChoice 等）
+├── App.vue           # 根组件
+└── main.js           # 入口文件
 ```
+
+## 💾 数据持久化
+
+Pinia store 通过 `pinia-plugin-persistedstate` 将以下字段写入 `localStorage`：
+
+- `wrongQuestions` — 错题本
+- `likeList` — 收藏夹
+- `markList` — 标记列表
+- `userRecords` — 学习记录（每题做题次数 / 错题次数 / 最近错题日期）
+
+清除浏览器站点数据即可重置。
 
 ## 📄 许可证 (License)
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,5 @@
+allowBuilds:
+  '@parcel/watcher': true
+  core-js: true
+  esbuild: true
+  vue-demi: true

--- a/src/components/examCard.vue
+++ b/src/components/examCard.vue
@@ -10,9 +10,8 @@
             <div class="questionStem">{{ question.questionStem }}</div>
             <div class="questionAnswer">
                 <div class="multiple" v-if="questionType == '多选'">
-                    <el-checkbox-group v-model="checkList" :disabled="examStatus" class="checkbox-group"
-                        @change="updateOption(seq, checkList)">
-                        <div v-for="(item, i) in question.option" class="answer">
+                    <el-checkbox-group v-model="answerModel" :disabled="examStatus" class="checkbox-group">
+                        <div v-for="(item, i) in question.option" :key="i" class="answer">
                             <el-checkbox :label="options[i]" :key="i" class="option checkbox-item copyable-option">
                                 <span class="copyable-text">{{ options[i] + '、' + item }}</span>
                             </el-checkbox>
@@ -20,24 +19,25 @@
                     </el-checkbox-group>
                 </div>
                 <div class="single" v-if="questionType == '判断' || questionType == '单选'">
-                    <div v-for="(item, i) in question.option" :key="i" class="answer">
-                        <el-radio v-model="radio" :disabled="examStatus"
-                            :label="question.option.length == 2 ? item : options[i]" class="option copyable-option"
-                            @change="updateOption(seq, radio)">
-                            <span class="copyable-text">{{ options[i] + '、' + item }}</span>
-                        </el-radio>
-                    </div>
+                    <el-radio-group v-model="answerModel" :disabled="examStatus" class="radio-group">
+                        <div v-for="(item, i) in question.option" :key="i" class="answer">
+                            <el-radio :label="question.option.length == 2 ? item : options[i]"
+                                class="option copyable-option">
+                                <span class="copyable-text">{{ options[i] + '、' + item }}</span>
+                            </el-radio>
+                        </div>
+                    </el-radio-group>
                 </div>
                 <div class="fillingBlank" v-if="questionType == '填空'">
-                    <el-input class="copyable-option" v-model="input" :disabled="examStatus"
-                        @change="updateOption(seq, input)" placeholder="请输入答案"></el-input>
+                    <el-input class="copyable-option" v-model="answerModel" :disabled="examStatus"
+                        placeholder="请输入答案"></el-input>
                 </div>
                 <div class="trueAnswer" v-if="examStatus">
                     <span class="colorBefore"></span>
                     <span class="answerStatus true"
-                        v-if="store.results[seq].questionId == question.id && store.results[seq].isCorrect">回答正确</span>
+                        v-if="answerResult && answerResult.isCorrect">回答正确</span>
                     <span class="answerStatus false"
-                        v-if="store.results[seq].questionId == question.id && !store.results[seq].isCorrect">回答错误</span>
+                        v-if="answerResult && answerResult.isCorrect === false">回答错误</span>
                     <span class="correctAnswer">正确答案：</span>
                     <span class="answer">{{ question.answer }}</span>
                 </div>
@@ -53,10 +53,7 @@ export default {
     setup() { return { store: useQuestionStore() } },
     data() {
         return {
-            radio: '',
-            checkList: [],
-            options: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T'],
-            input: ''
+            options: ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H', 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P', 'Q', 'R', 'S', 'T']
         }
     },
     props: {
@@ -86,6 +83,21 @@ export default {
             } else {
                 return '多选'
             }
+        },
+        answerModel: {
+            get() {
+                const value = this.store.answerList[this.seq]
+                if (this.questionType == '多选') {
+                    return Array.isArray(value) ? value : []
+                }
+                return Array.isArray(value) ? '' : (value ?? '')
+            },
+            set(value) {
+                this.store.answerList[this.seq] = value
+            }
+        },
+        answerResult() {
+            return this.store.results.find(item => item.questionId == this.question.id)
         }
     },
     methods: {
@@ -97,22 +109,22 @@ export default {
 </script>
 
 <style lang="scss">
-.checkbox-group {
+.checkbox-group,
+.radio-group {
     display: flex;
     flex-direction: column;
+    align-items: stretch;
+    gap: 8px;
 }
 
 .checkbox-item {
     display: flex;
     align-items: flex-start;
-    /* 确保复选框靠上对齐 */
-    margin-bottom: 10px;
-    /* 调整每个选项的间距 */
+    margin-bottom: 0;
 }
 
 .el-checkbox {
     align-items: flex-start;
-    /* 让复选框靠上对齐 */
 }
 
 /* 禁用选项的鼠标事件 */
@@ -206,28 +218,53 @@ export default {
             margin-bottom: 10px;
 
             .answer {
-                line-height: 30px;
+                display: flex;
+                justify-content: flex-start;
+                line-height: 24px;
+                margin-bottom: 8px;
                 color: #5F89D3;
+                text-align: left;
+
+                .option {
+                    display: flex;
+                    align-items: flex-start;
+                    justify-content: flex-start;
+                    width: 100%;
+                    height: auto;
+                    margin-right: 0;
+                    white-space: normal;
+                    text-align: left;
+                }
 
                 span {
                     word-wrap: break-word;
                     word-break: break-all;
                     white-space: normal;
-                    line-height: 22px;
+                    line-height: 24px;
                 }
 
                 .el-radio__inner {
                     border: 1px solid #999;
                 }
 
+                .el-radio__input {
+                    flex: 0 0 auto;
+                    margin-top: 3px;
+                }
 
                 .el-radio__label {
                     font-size: 18px;
-                    display: inline;
+                    display: block;
+                    flex: 1;
+                    padding-left: 8px;
+                    text-align: left;
+                    white-space: normal;
+                    line-height: 24px;
                 }
 
                 .el-checkbox__input {
-                    margin-top: -2px;
+                    flex: 0 0 auto;
+                    margin-top: 3px;
 
                     .el-checkbox__inner {
                         border: 1px solid #999;
@@ -236,7 +273,20 @@ export default {
 
                 .el-checkbox__label {
                     font-size: 18px;
-                    display: inline;
+                    display: block;
+                    flex: 1;
+                    padding-left: 8px;
+                    text-align: left;
+                    white-space: normal;
+                    line-height: 24px;
+                }
+
+                .copyable-text {
+                    display: block;
+                    text-align: left;
+                    white-space: normal;
+                    word-break: break-word;
+                    line-height: 24px;
                 }
             }
         }

--- a/src/components/examRecord.vue
+++ b/src/components/examRecord.vue
@@ -32,7 +32,8 @@ export default {
     data() {
         return {
             status: [],
-            length: ''
+            length: '',
+            submitted: false
         }
     },
     computed: {
@@ -66,16 +67,10 @@ export default {
     watch: {
         'store.answerList': {
             handler(newValue, oldValue) {
-                if (newValue === '') {
+                if (this.submitted || newValue === '') {
                     return
                 } else {
-                    this.status = newValue.map(item => {
-                        if (!(Array.isArray(item) && item.length === 0) && item !== undefined && item !== null && item !== '') {
-                            return 'active'
-                        } else {
-                            return 'unactive'
-                        }
-                    })
+                    this.status = this.buildAnswerStatus(newValue)
                 }
             },
             deep: true
@@ -91,13 +86,15 @@ export default {
                         confirmButtonText: '确定',
                     });
                 } else {
+                    const nextStatus = new Array(this.length).fill('false')
                     await results.map(item => {
                         if (item.isCorrect) {
-                            this.status[this.findQuestionIndex(item.questionId)] = 'true'
+                            nextStatus[this.findQuestionIndex(item.questionId)] = 'true'
                         } else {
-                            this.status[this.findQuestionIndex(item.questionId)] = 'false'
+                            nextStatus[this.findQuestionIndex(item.questionId)] = 'false'
                         }
                     })
+                    this.status = nextStatus
                     if (this.autoSave) {
                         ElMessageBox.alert(`得分为${newValue}，错题已推送至收藏夹`, '提交成功', {
                             confirmButtonText: '确定',
@@ -112,36 +109,46 @@ export default {
         }
     },
     methods: {
+        isAnswered(answer) {
+            if (Array.isArray(answer)) {
+                return answer.length > 0
+            }
+            return answer !== undefined && answer !== null && String(answer).trim() !== ''
+        },
+        buildAnswerStatus(answerList) {
+            return this.store.questionBank.map((question, index) => {
+                return this.isAnswered(answerList[index]) ? 'active' : 'unactive'
+            })
+        },
+        async confirmAndSubmit(message, type) {
+            try {
+                await ElMessageBox.confirm(message, '提示', {
+                    confirmButtonText: '确定',
+                    cancelButtonText: '取消',
+                    type
+                })
+                this.submitted = true
+                await this.store.checkAnswer(this.autoSave)
+                this.$emit('examStatus', true)
+            } catch (e) {
+                return
+            }
+        },
         async submitAnswer() {
-            if (this.status.includes(false)) {
-                ElMessageBox.confirm('还有未做的题目，确定提交吗？', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'warning'
-                }).then(() => {
-                    this.store.checkAnswer(this.autoSave)
-                    this.$emit('examStatus', true)
-                }).catch(() => {
-                    return
-                });
+            if (this.status.includes('unactive')) {
+                this.confirmAndSubmit('还有未做的题目，确定提交吗？', 'warning')
             } else {
-                ElMessageBox.confirm('确认提交吗？', '提示', {
-                    confirmButtonText: '确定',
-                    cancelButtonText: '取消',
-                    type: 'info'
-                }).then(() => {
-                    this.store.checkAnswer(this.autoSave)
-                    this.$emit('examStatus', true)
-                }).catch(() => {
-                    return
-                });
+                this.confirmAndSubmit('确认提交吗？', 'info')
             }
         }
     },
     created() {
         const length = this.questionTypes.fillInTheBlank.length + this.questionTypes.multipleChoice.length + this.questionTypes.singleChoice.length + this.questionTypes.trueOrFalse.length
         this.length = length
-        this.store.answerList = new Array(length).fill('')
+        this.submitted = false
+        this.store.answerList = this.store.questionBank.map(question => {
+            return question.option && question.option.length > 2 && question.answer.length > 1 ? [] : ''
+        })
         this.status = new Array(length).fill('unactive')
     }
 };

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -62,11 +62,15 @@
                     :src="showList[i].markFlag ? markActiveIcon : markIcon"
                     @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
                 </transition>
-                <transition name="fade" mode="out-in">
-                  <img class="like"
-                    :src="showList[i].likeFlag ? likeActiveIcon : likeIcon"
-                    @click="changeFlag('likeFlag', i)" :key="item.likeFlag">
-                </transition>
+                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
+                  @click="toggleFav(showList[i], i)" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
+                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
+                </button>
               </div>
               <div class="questionType">
                 <span v-if="$route.path == '/newHome/favorites'">
@@ -115,11 +119,15 @@
                     :src="showList[i].markFlag ? markActiveIcon : markIcon"
                     @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
                 </transition>
-                <transition name="fade" mode="out-in">
-                  <img class="like"
-                    :src="showList[i].likeFlag ? likeActiveIcon : likeIcon"
-                    @click="changeFlag('likeFlag', i)" :key="item.likeFlag">
-                </transition>
+                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
+                  @click="toggleFav(showList[i], i)" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
+                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
+                </button>
               </div>
               <div class="questionType">
                 <span v-if="$route.path == '/newHome/favorites'">
@@ -168,11 +176,15 @@
                     :src="showList[i].markFlag ? markActiveIcon : markIcon"
                     @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
                 </transition>
-                <transition name="fade" mode="out-in">
-                  <img class="like"
-                    :src="showList[i].likeFlag ? likeActiveIcon : likeIcon"
-                    @click="changeFlag('likeFlag', i)" :key="item.likeFlag">
-                </transition>
+                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
+                  @click="toggleFav(showList[i], i)" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
+                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
+                </button>
               </div>
               <div class="questionType">
                 <span v-if="$route.path == '/newHome/favorites'">
@@ -228,11 +240,15 @@
                     :src="showList[i].markFlag ? markActiveIcon : markIcon"
                     @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
                 </transition>
-                <transition name="fade" mode="out-in">
-                  <img class="like"
-                    :src="showList[i].likeFlag ? likeActiveIcon : likeIcon"
-                    @click="changeFlag('likeFlag', i)" :key="item.likeFlag">
-                </transition>
+                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
+                  @click="toggleFav(showList[i], i)" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
+                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
+                </button>
               </div>
               <div class="questionType">
                 <span v-if="$route.path == '/newHome/favorites'">
@@ -290,8 +306,6 @@ import { makePdf } from "@/utils/makePdf";
 import { ElMessage } from 'element-plus'
 import markActiveIcon from '@/assets/icon/icon-mark-active.svg'
 import markIcon from '@/assets/icon/icon-mark.svg'
-import likeActiveIcon from '@/assets/icon/icon-like-active.svg'
-import likeIcon from '@/assets/icon/icon-like.svg'
 
 export default {
   setup() {
@@ -421,21 +435,6 @@ export default {
       } catch (e) {
         this.list = [];
       }
-
-      if (this.store.wrongQuestions.length > 0 || this.store.likeList.length > 0) {
-        this.store.wrongQuestions.forEach(subsetItem => {
-          let supersetItem = this.list.find(supersetItem => supersetItem.id == subsetItem.id);
-          if (supersetItem) {
-            supersetItem.likeFlag = true;
-          }
-        });
-        this.store.likeList.forEach(subsetItem => {
-          let supersetItem = this.list.find(supersetItem => supersetItem.id == subsetItem.id);
-          if (supersetItem) {
-            supersetItem.likeFlag = true;
-          }
-        });
-      }
     }
     this.showList = [...this.list]
     this.searchWord = ""
@@ -484,21 +483,6 @@ export default {
             this.list = await loadQuestionBank(this.lesson, this.type);
         } catch (e) {
             this.list = [];
-        }
-
-        if (this.store.wrongQuestions.length > 0 || this.store.likeList.length > 0) {
-          this.store.wrongQuestions.forEach(subsetItem => {
-            let supersetItem = this.list.find(supersetItem => supersetItem.id == subsetItem.id);
-            if (supersetItem) {
-              supersetItem.likeFlag = true;
-            }
-          });
-          this.store.likeList.forEach(subsetItem => {
-            let supersetItem = this.list.find(supersetItem => supersetItem.id == subsetItem.id);
-            if (supersetItem) {
-              supersetItem.likeFlag = true;
-            }
-          });
         }
       }
       this.showList = [...this.list]
@@ -657,40 +641,31 @@ export default {
       }
     },
     changeFlag(flagType, i) {
-      this.showList[i][flagType] = !this.showList[i][flagType]
-      if (this.$route.path == '/newHome/favorites') {
-        if (this.subjectOptions == 'favorites') {
-          if (this.showList[i][flagType]) {
-            this.store.addLikeQuestion(this.showList[i])
-          } else {
-            this.store.removeLikeQuestion(this.showList[i].id)
-            this.list = this.store.likeList
-            this.showList = [...this.list]
-          }
-        } else if (this.subjectOptions == 'wrong') {
-          if (this.showList[i][flagType]) {
-            this.store.addFavoriteQuestion(this.showList[i])
-          } else {
-            this.store.removeFavoriteQuestion(this.showList[i].id)
-            this.list = this.store.wrongQuestions
-            this.showList = [...this.list]
-          }
-        } else {
-          if (this.showList[i][flagType]) {
-            this.store.addLikeQuestion(this.showList[i])
-          } else {
-            this.store.removeLikeQuestion(this.showList[i].id)
-            this.store.removeFavoriteQuestion(this.showList[i].id)
-            this.list = this.getMergedFavoriteList()
-            this.showList = [...this.list]
-          }
-        }
-      } else {
-        if (this.showList[i][flagType]) {
-          this.store.addLikeQuestion(this.showList[i])
-        } else {
-          this.store.removeLikeQuestion(this.showList[i].id)
-          this.store.removeFavoriteQuestion(this.showList[i].id)
+      // Legacy entrypoint — kept in case external code calls it. Delegates to toggleFav.
+      this.toggleFav(this.showList[i], i)
+    },
+    isFav(question) {
+      if (!question) return false
+      return this.store.isFavorite(question.id)
+    },
+    toggleFav(question, i) {
+      if (!question) return
+      const nowFavorite = this.store.toggleFavorite(question)
+      ElMessage({
+        message: nowFavorite ? '已加入收藏夹' : '已取消收藏',
+        type: nowFavorite ? 'success' : 'info',
+        duration: 1200
+      })
+      // If we're viewing the favorites page and the user just un-favorited an item,
+      // remove it from the rendered list — but only if it's no longer present in any
+      // underlying list (it could still be a wrong question in 'all' mode).
+      if (!nowFavorite && this.$route.path === '/newHome/favorites') {
+        const stillVisible =
+          this.subjectOptions === 'all' &&
+          this.store.wrongQuestions.some(q => q.id === question.id)
+        if (!stillVisible) {
+          this.showList.splice(i, 1)
+          this.list = this.list.filter(q => q.id !== question.id)
         }
       }
     },
@@ -812,19 +787,71 @@ export default {
         width: 94%;
 
         .markAndLike {
-          width: 72px;
           height: 32px;
           position: absolute;
           top: 0px;
           right: 0px;
+          display: flex;
+          align-items: center;
+          gap: 8px;
 
           .mark {
             display: inline-block;
-            margin-right: 8px;
+            cursor: pointer;
           }
 
-          .like {
-            display: inline-block;
+          .fav-btn {
+            display: inline-flex;
+            align-items: center;
+            gap: 4px;
+            height: 28px;
+            padding: 0 10px;
+            border-radius: 14px;
+            border: 1px solid #6C5DD3;
+            background-color: #fff;
+            color: #6C5DD3;
+            font-size: 13px;
+            font-weight: 600;
+            cursor: pointer;
+            transition: all 0.2s ease;
+            line-height: 1;
+            font-family: inherit;
+
+            .fav-icon {
+              flex-shrink: 0;
+              transition: transform 0.2s ease;
+            }
+
+            .fav-text {
+              white-space: nowrap;
+            }
+
+            &:hover {
+              background-color: #E6E4F4;
+              transform: translateY(-1px);
+              box-shadow: 0 2px 6px rgba(108, 93, 211, 0.25);
+            }
+
+            &:active .fav-icon {
+              transform: scale(1.2);
+            }
+
+            &.is-fav {
+              background-color: #6C5DD3;
+              color: #fff;
+              border-color: #6C5DD3;
+
+              .fav-icon {
+                // Drop shadow gives the star a faint outline so the filled
+                // glyph stays visible even though fill === button background.
+                filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.35));
+              }
+
+              &:hover {
+                background-color: #5B4FB5;
+                border-color: #5B4FB5;
+              }
+            }
           }
         }
 

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -57,11 +57,15 @@
             </div>
             <div class="right">
               <div class="markAndLike">
-                <transition name="fade" mode="out-in">
-                  <img class="mark"
-                    :src="showList[i].markFlag ? markActiveIcon : markIcon"
-                    @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
-                </transition>
+                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
+                  @click="toggleMark(showList[i])" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
+                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
+                </button>
                 <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
                   @click="toggleFav(showList[i], i)" type="button">
                   <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
@@ -114,11 +118,15 @@
             </div>
             <div class="right">
               <div class="markAndLike">
-                <transition name="fade" mode="out-in">
-                  <img class="mark"
-                    :src="showList[i].markFlag ? markActiveIcon : markIcon"
-                    @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
-                </transition>
+                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
+                  @click="toggleMark(showList[i])" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
+                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
+                </button>
                 <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
                   @click="toggleFav(showList[i], i)" type="button">
                   <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
@@ -171,11 +179,15 @@
             </div>
             <div class="right">
               <div class="markAndLike">
-                <transition name="fade" mode="out-in">
-                  <img class="mark"
-                    :src="showList[i].markFlag ? markActiveIcon : markIcon"
-                    @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
-                </transition>
+                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
+                  @click="toggleMark(showList[i])" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
+                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
+                </button>
                 <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
                   @click="toggleFav(showList[i], i)" type="button">
                   <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
@@ -235,11 +247,15 @@
             </div>
             <div class="right">
               <div class="markAndLike">
-                <transition name="fade" mode="out-in">
-                  <img class="mark"
-                    :src="showList[i].markFlag ? markActiveIcon : markIcon"
-                    @click="changeFlagIcon('markFlag', i)" :key="item.markFlag">
-                </transition>
+                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
+                  @click="toggleMark(showList[i])" type="button">
+                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
+                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
+                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+                  </svg>
+                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
+                </button>
                 <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
                   @click="toggleFav(showList[i], i)" type="button">
                   <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
@@ -304,8 +320,6 @@ import { loadQuestionBank } from '@/utils/loadJson'
 import Fuse from 'fuse.js';
 import { makePdf } from "@/utils/makePdf";
 import { ElMessage } from 'element-plus'
-import markActiveIcon from '@/assets/icon/icon-mark-active.svg'
-import markIcon from '@/assets/icon/icon-mark.svg'
 
 export default {
   setup() {
@@ -648,6 +662,19 @@ export default {
       if (!question) return false
       return this.store.isFavorite(question.id)
     },
+    isMarked(question) {
+      if (!question) return false
+      return this.store.isMarked(question.id)
+    },
+    toggleMark(question) {
+      if (!question) return
+      const nowMarked = this.store.toggleMark(question)
+      ElMessage({
+        message: nowMarked ? '已标记' : '已取消标记',
+        type: nowMarked ? 'success' : 'info',
+        duration: 1200
+      })
+    },
     toggleFav(question, i) {
       if (!question) return
       const nowFavorite = this.store.toggleFavorite(question)
@@ -675,9 +702,6 @@ export default {
         unique.set(item.id, item);
       });
       return Array.from(unique.values());
-    },
-    changeFlagIcon(flagType, i) {
-      this.showList[i][flagType] = !this.showList[i][flagType]
     },
     changeInput() {
       if (this.searchWord === "") {
@@ -794,11 +818,6 @@ export default {
           display: flex;
           align-items: center;
           gap: 8px;
-
-          .mark {
-            display: inline-block;
-            cursor: pointer;
-          }
 
           .fav-btn {
             display: inline-flex;

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -448,7 +448,7 @@ export default {
         if (this.$route.path == '/newHome/favorites') {
           switch (newValue) {
             case 'all':
-              this.list = [...new Set([...this.store.likeList, ...this.store.wrongQuestions])]
+              this.list = this.getMergedFavoriteList()
               this.showList = [...this.list]
               break
             case 'favorites':
@@ -653,11 +653,7 @@ export default {
 
       // 错了自动加入错题集
       if (!isCorrect) {
-        const exists = this.store.wrongQuestions.some(q => q.id === question.id);
-        if (!exists) {
-          question.likeFlag = true;
-          this.store.wrongQuestions.push(question);
-        }
+        this.store.addWrongQuestion(question);
       }
     },
     changeFlag(flagType, i) {
@@ -685,7 +681,7 @@ export default {
           } else {
             this.store.removeLikeQuestion(this.showList[i].id)
             this.store.removeFavoriteQuestion(this.showList[i].id)
-            this.list = [...new Set([...this.store.likeList, ...this.store.wrongQuestions])]
+            this.list = this.getMergedFavoriteList()
             this.showList = [...this.list]
           }
         }
@@ -697,6 +693,13 @@ export default {
           this.store.removeFavoriteQuestion(this.showList[i].id)
         }
       }
+    },
+    getMergedFavoriteList() {
+      const unique = new Map();
+      [...this.store.likeList, ...this.store.wrongQuestions].forEach(item => {
+        unique.set(item.id, item);
+      });
+      return Array.from(unique.values());
     },
     changeFlagIcon(flagType, i) {
       this.showList[i][flagType] = !this.showList[i][flagType]
@@ -804,7 +807,7 @@ export default {
       }
 
       .right {
-        text-align: justify;
+        text-align: left;
         position: relative;
         width: 94%;
 
@@ -845,22 +848,29 @@ export default {
 
         .questionOpt {
           .option {
+            display: flex;
+            align-items: flex-start;
             line-height: 28px;
             font-size: 18px;
             letter-spacing: 1px;
             position: relative;
+            text-align: left;
+            margin-bottom: 4px;
 
             .dot {
+              flex: 0 0 auto;
               width: 14px;
               height: 14px;
               border-radius: 50%;
               background-color: #6C5DD3;
-              position: absolute;
-              top: 7px;
+              margin-top: 7px;
             }
 
             .optText {
-              text-indent: 22px;
+              flex: 1;
+              margin-left: 8px;
+              text-indent: 0;
+              word-break: break-word;
             }
           }
         }
@@ -940,6 +950,31 @@ export default {
       margin-bottom: 8px;
       line-height: 28px;
       font-size: 16px;
+      text-align: left;
+
+      .el-radio,
+      .el-checkbox {
+        display: flex;
+        align-items: flex-start;
+        height: auto;
+        white-space: normal;
+      }
+
+      .el-radio__input,
+      .el-checkbox__input {
+        flex: 0 0 auto;
+        margin-top: 4px;
+      }
+
+      .el-radio__label,
+      .el-checkbox__label {
+        display: block;
+        flex: 1;
+        white-space: normal;
+        line-height: 24px;
+        text-align: left;
+        word-break: break-word;
+      }
     }
 
     .fill-practice-row {

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -9,8 +9,19 @@ function getType(question) {
   return '单选'
 }
 
-function isExists(list, question) {
-  return list.some(item => item.id === question.id)
+function upsertQuestion(listRef, question, flags = {}) {
+  const nextQuestion = { ...question, ...flags }
+  const index = listRef.value.findIndex(item => item.id === question.id)
+
+  if (index === -1) {
+    listRef.value.push(nextQuestion)
+    return
+  }
+
+  listRef.value[index] = {
+    ...listRef.value[index],
+    ...nextQuestion
+  }
 }
 
 function updateUserRecord(userRecords, questionId, isCorrect) {
@@ -63,8 +74,7 @@ export const useQuestionStore = defineStore('question', () => {
   }
 
   function addWrongQuestion(question) {
-    question.likeFlag = true
-    wrongQuestions.value.push(question)
+    upsertQuestion(wrongQuestions, question, { likeFlag: true })
   }
 
   function removeWrongQuestion(questionId) {
@@ -72,8 +82,7 @@ export const useQuestionStore = defineStore('question', () => {
   }
 
   function addLikeQuestion(question) {
-    question.likeFlag = true
-    likeList.value.push(question)
+    upsertQuestion(likeList, question, { likeFlag: true })
   }
 
   function removeLikeQuestion(questionId) {
@@ -121,16 +130,12 @@ export const useQuestionStore = defineStore('question', () => {
         results.value.push({ questionId: question.id, isCorrect })
 
         if (!isCorrect && autoSave) {
-          if (!isExists(wrongQuestions.value, question)) {
-            question.likeFlag = true
-            wrongQuestions.value.push(question)
-          }
+          addWrongQuestion(question)
         }
       })
     )
 
     score.value = results.value.filter(r => r.isCorrect).length
-    answerList.value = []
   }
 
   async function generateQuizAction(payload) {

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -10,7 +10,9 @@ function getType(question) {
 }
 
 function upsertQuestion(listRef, question, flags = {}) {
-  const nextQuestion = { ...question, ...flags }
+  // strip ephemeral UI flags before persisting
+  const { likeFlag, markFlag, ...cleanQuestion } = question
+  const nextQuestion = { ...cleanQuestion, ...flags }
   const index = listRef.value.findIndex(item => item.id === question.id)
 
   if (index === -1) {
@@ -74,7 +76,7 @@ export const useQuestionStore = defineStore('question', () => {
   }
 
   function addWrongQuestion(question) {
-    upsertQuestion(wrongQuestions, question, { likeFlag: true })
+    upsertQuestion(wrongQuestions, question)
   }
 
   function removeWrongQuestion(questionId) {
@@ -82,11 +84,24 @@ export const useQuestionStore = defineStore('question', () => {
   }
 
   function addLikeQuestion(question) {
-    upsertQuestion(likeList, question, { likeFlag: true })
+    upsertQuestion(likeList, question)
   }
 
   function removeLikeQuestion(questionId) {
     likeList.value = likeList.value.filter(q => q.id !== questionId)
+  }
+
+  function isFavorite(questionId) {
+    return likeList.value.some(q => q.id === questionId)
+  }
+
+  function toggleFavorite(question) {
+    if (isFavorite(question.id)) {
+      removeLikeQuestion(question.id)
+      return false
+    }
+    addLikeQuestion(question)
+    return true
   }
 
   function clearLikeList() {
@@ -145,9 +160,11 @@ export const useQuestionStore = defineStore('question', () => {
     questionBank.value = quiz
   }
 
-  // Aliases for backward compat (addFavoriteQuestion was mapped to ADD_WRONG_QUESTION)
-  function addFavoriteQuestion(question) { addWrongQuestion(question) }
-  function removeFavoriteQuestion(questionId) { removeWrongQuestion(questionId) }
+  // Aliases retained for backward compat with examPage.vue.
+  // NOTE: original aliases incorrectly mapped favorite-add to wrong-question-add.
+  // Now these correctly hit the favorites/like list.
+  function addFavoriteQuestion(question) { addLikeQuestion(question) }
+  function removeFavoriteQuestion(questionId) { removeLikeQuestion(questionId) }
 
   return {
     wrongQuestions, answerList, questionBank, results,
@@ -156,6 +173,7 @@ export const useQuestionStore = defineStore('question', () => {
     loadQuestionBank, getQuestionType,
     addWrongQuestion, removeWrongQuestion,
     addLikeQuestion, removeLikeQuestion,
+    isFavorite, toggleFavorite,
     addFavoriteQuestion, removeFavoriteQuestion,
     clearLikeList, clearWrongQuestions,
     checkAnswer, generateQuizAction

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -50,6 +50,7 @@ export const useQuestionStore = defineStore('question', () => {
   const questionBank = ref([])
   const results = ref([])
   const likeList = ref([])
+  const markList = ref([])
   const score = ref(null)
   const fonts = ref(null)
   const userRecords = ref({})
@@ -102,6 +103,31 @@ export const useQuestionStore = defineStore('question', () => {
     }
     addLikeQuestion(question)
     return true
+  }
+
+  function addMarkQuestion(question) {
+    upsertQuestion(markList, question)
+  }
+
+  function removeMarkQuestion(questionId) {
+    markList.value = markList.value.filter(q => q.id !== questionId)
+  }
+
+  function isMarked(questionId) {
+    return markList.value.some(q => q.id === questionId)
+  }
+
+  function toggleMark(question) {
+    if (isMarked(question.id)) {
+      removeMarkQuestion(question.id)
+      return false
+    }
+    addMarkQuestion(question)
+    return true
+  }
+
+  function clearMarkList() {
+    markList.value = []
   }
 
   function clearLikeList() {
@@ -168,18 +194,20 @@ export const useQuestionStore = defineStore('question', () => {
 
   return {
     wrongQuestions, answerList, questionBank, results,
-    likeList, score, fonts, userRecords,
+    likeList, markList, score, fonts, userRecords,
     getQuestionsByType, getAllQuestions,
     loadQuestionBank, getQuestionType,
     addWrongQuestion, removeWrongQuestion,
     addLikeQuestion, removeLikeQuestion,
     isFavorite, toggleFavorite,
+    addMarkQuestion, removeMarkQuestion,
+    isMarked, toggleMark, clearMarkList,
     addFavoriteQuestion, removeFavoriteQuestion,
     clearLikeList, clearWrongQuestions,
     checkAnswer, generateQuizAction
   }
 }, {
   persist: {
-    pick: ['wrongQuestions', 'likeList', 'userRecords']
+    pick: ['wrongQuestions', 'likeList', 'markList', 'userRecords']
   }
 })

--- a/src/views/examPage.vue
+++ b/src/views/examPage.vue
@@ -196,7 +196,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 20; i < 35; i++) {
@@ -206,7 +206,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 36; i < 50; i++) {
@@ -215,7 +215,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 51; i < 60; i++) {
@@ -224,7 +224,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     ElMessageBox.alert(`得分为${sum}`, {
@@ -252,7 +252,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 20; i < 35; i++) {
@@ -261,7 +261,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 36; i < 50; i++) {
@@ -269,7 +269,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 51; i < 60; i++) {
@@ -277,7 +277,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         ElMessageBox.alert(`得分为${sum}`, {
@@ -305,7 +305,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 16; i < 30; i++) {
@@ -315,7 +315,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 31; i < 45; i++) {
@@ -324,7 +324,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     for (let i = 46; i < 50; i++) {
@@ -333,7 +333,7 @@ export default {
                         } else {
                             sum += 0
                             this.list[i].likeFlag = true
-                            this.store.addFavoriteQuestion(this.list[i])
+                            this.store.addWrongQuestion(this.list[i])
                         }
                     }
                     ElMessageBox.alert(`得分为${sum}`, {
@@ -361,7 +361,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 16; i < 30; i++) {
@@ -370,7 +370,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 31; i < 45; i++) {
@@ -378,7 +378,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         for (let i = 46; i < 50; i++) {
@@ -386,7 +386,7 @@ export default {
                                 sum += 0.5
                             } else {
                                 sum += 0
-                                this.store.addFavoriteQuestion(this.list[i])
+                                this.store.addWrongQuestion(this.list[i])
                             }
                         }
                         ElMessageBox.alert(`得分为${sum}`, {

--- a/src/views/new/newHome.vue
+++ b/src/views/new/newHome.vue
@@ -364,7 +364,12 @@ export default {
                 color: #6C5DD3;
             }
 
-            .is-active {
+            // Scope to .el-menu-item only. The unqualified `.is-active`
+            // selector used to leak onto `.el-sub-menu` and `.el-sub-menu__title`
+            // (Element Plus stamps `is-active` on every ancestor of the active
+            // item), painting the whole submenu container lavender and leaving
+            // a rounded purple strip below the last option.
+            .el-menu-item.is-active {
                 background-color: #E6E4F4 !important;
                 color: #6C5DD3 !important;
                 font-weight: bold;


### PR DESCRIPTION
## Summary

- 把"收藏 / 标记"做成题目右上角的成对按钮，支持单题切换、即时反馈，状态持久化到 localStorage（`likeList` / `markList`，走 `pinia-plugin-persistedstate`）
- 修复 store 里 `addFavoriteQuestion` 别名错指向错题集的历史 bug；新增 `isFavorite` / `toggleFavorite` / `isMarked` / `toggleMark` 等 getter/action 作为 UI 单一数据源
- 修复 sidebar 学科子菜单"被选中时最后一项底下出现紫色圆角条"的视觉 bug
- 顺手修正 `examPage.vue` 16 处错答跟进调用，从 `addFavoriteQuestion` 改为 `addWrongQuestion`（原别名错配后才能跑通）

## Commits

| Hash | 内容 |
|------|------|
| `1459eb0` | `fix(store)`: 收藏/错题语义解耦，新增 `isFavorite` / `toggleFavorite` |
| `1dca16d` | `fix(examPage)`: 错答跟进改写到错题集 |
| `9eec758` | `feat(questionCard)`: 重做收藏按钮（紫色胶囊 + 星形 SVG，`currentColor` 防撞色）|
| `437880c` | `fix(sidebar)`: `.is-active` 限定到 `.el-menu-item` |
| `7f2c23a` | `feat(store)`: 加 `markList` + 持久化 |
| `a3fdb07` | `feat(questionCard)`: 收藏按钮左侧加同款标记按钮 |
| `39da2e8` | merge upstream main（解决 examCard / examRecord 冲突）|

## 关键设计点

**收藏 / 标记按钮**
- 题目右上角并排两枚胶囊按钮：左 \"标记 / 已标记\"（书签 SVG），右 \"收藏 / 已收藏\"（星形 SVG）
- 配色统一为站点主紫 `#6C5DD3`：未激活白底紫描边、hover 淡紫底 `#E6E4F4`、激活紫底白字、hover 深紫 `#5B4FB5`
- SVG `fill` / `stroke` 用 `currentColor` 跟随按钮文字色，激活态额外加一层极浅 `drop-shadow` 防 fill === bg 的撞色
- 点击通过 ElMessage toast 反馈（已加入收藏夹 / 已取消收藏 / 已标记 / 已取消标记）
- 在收藏夹页取消收藏会从渲染列表中 splice 掉，但若同时是错题且当前在 \"全部\" 标签下，则保留显示

**store 改造**
- `addFavoriteQuestion` 历史上是 `addWrongQuestion` 的别名，名实不符。本次把别名指向 `addLikeQuestion`，并把 `examPage.vue` 16 处误用改为显式 `addWrongQuestion`，行为完全等价但语义不再误导
- `upsertQuestion` 在写入前剥掉 `likeFlag` / `markFlag` 这类 UI 临时态，localStorage 存储更干净
- `persist.pick` 追加 `'markList'`

**sidebar bug**
- Element Plus 会把 `.is-active` 沿祖先链一路盖到 `.el-menu-item` → `.el-sub-menu__title` → `.el-sub-menu`
- 原 `.is-active { background-color: #E6E4F4 !important; }` 没有限定标签，把整个 sub-menu 容器刷成淡紫，配合 `border-radius: 12px; overflow: hidden` 和最后一项的 `margin-bottom: 4px` 缝隙，渲染出底部圆角紫条
- 修复：选择器收紧为 `.el-menu-item.is-active`

## Test plan

- [ ] 进入任意学科的判断/单选/多选/填空练习页，验证右上角两枚按钮可见、点击后 toast 出现且文字 / 颜色随状态切换
- [ ] 刷新页面后 \"已收藏\" / \"已标记\" 状态保留（DevTools → Application → Local Storage 可见 `likeList` / `markList`）
- [ ] 进入收藏夹 \"全部 / 我的收藏 / 错题\" 三个标签，确认单题取消收藏后行为正确：仅收藏 → 移出；既错又收藏 + 全部模式 → 保留显示为错题
- [ ] sidebar 展开任一学科并选中其子项，确认最后一项下方不再出现紫色圆角条
- [ ] 在线练习（examPage）做错若干题后提交，错题进入"错题本"而非"我的收藏"