### PR TITLE
refactor: 简化错题/标记/收藏的数据模型，解决错题与收藏夹混淆

### DIFF
--- a/src/components/examRecord.vue
+++ b/src/components/examRecord.vue
@@ -101,7 +101,7 @@ export default {
                     })
                     this.status = nextStatus
                     if (this.autoSave) {
-                        ElMessageBox.alert(`得分为${newValue}，错题已推送至收藏夹`, '提交成功', {
+                        ElMessageBox.alert(`得分为${newValue}，错题已推送至错题本`, '提交成功', {
                             confirmButtonText: '确定',
                         });
                     } else {

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -670,7 +670,7 @@ export default {
       if (!question) return
       const nowMarked = this.store.toggleMark(question)
       ElMessage({
-        message: nowMarked ? '已标记' : '已取消标记',
+        message: nowMarked ? '已加入错题本' : '已从错题本移除',
         type: nowMarked ? 'success' : 'info',
         duration: 1200
       })
@@ -683,18 +683,6 @@ export default {
         type: nowFavorite ? 'success' : 'info',
         duration: 1200
       })
-      // If we're viewing the favorites page and the user just un-favorited an item,
-      // remove it from the rendered list — but only if it's no longer present in any
-      // underlying list (it could still be a wrong question in 'all' mode).
-      if (!nowFavorite && this.$route.path === '/newHome/favorites') {
-        const stillVisible =
-          this.subjectOptions === 'all' &&
-          this.store.wrongQuestions.some(q => q.id === question.id)
-        if (!stillVisible) {
-          this.showList.splice(i, 1)
-          this.list = this.list.filter(q => q.id !== question.id)
-        }
-      }
     },
     getMergedFavoriteList() {
       const unique = new Map();

--- a/src/stores/question.js
+++ b/src/stores/question.js
@@ -50,7 +50,6 @@ export const useQuestionStore = defineStore('question', () => {
   const questionBank = ref([])
   const results = ref([])
   const likeList = ref([])
-  const markList = ref([])
   const score = ref(null)
   const fonts = ref(null)
   const userRecords = ref({})
@@ -105,29 +104,21 @@ export const useQuestionStore = defineStore('question', () => {
     return true
   }
 
-  function addMarkQuestion(question) {
-    upsertQuestion(markList, question)
-  }
-
-  function removeMarkQuestion(questionId) {
-    markList.value = markList.value.filter(q => q.id !== questionId)
-  }
-
+  // "Mark" in the UI is a synonym for "add to wrong-question list". The two
+  // were originally separate concepts but converged: the user wants the same
+  // bookmark glyph to flag a question as something they got wrong / want to
+  // revisit, which is exactly what wrongQuestions already stores.
   function isMarked(questionId) {
-    return markList.value.some(q => q.id === questionId)
+    return wrongQuestions.value.some(q => q.id === questionId)
   }
 
   function toggleMark(question) {
     if (isMarked(question.id)) {
-      removeMarkQuestion(question.id)
+      removeWrongQuestion(question.id)
       return false
     }
-    addMarkQuestion(question)
+    addWrongQuestion(question)
     return true
-  }
-
-  function clearMarkList() {
-    markList.value = []
   }
 
   function clearLikeList() {
@@ -194,20 +185,19 @@ export const useQuestionStore = defineStore('question', () => {
 
   return {
     wrongQuestions, answerList, questionBank, results,
-    likeList, markList, score, fonts, userRecords,
+    likeList, score, fonts, userRecords,
     getQuestionsByType, getAllQuestions,
     loadQuestionBank, getQuestionType,
     addWrongQuestion, removeWrongQuestion,
     addLikeQuestion, removeLikeQuestion,
     isFavorite, toggleFavorite,
-    addMarkQuestion, removeMarkQuestion,
-    isMarked, toggleMark, clearMarkList,
+    isMarked, toggleMark,
     addFavoriteQuestion, removeFavoriteQuestion,
     clearLikeList, clearWrongQuestions,
     checkAnswer, generateQuizAction
   }
 }, {
   persist: {
-    pick: ['wrongQuestions', 'likeList', 'markList', 'userRecords']
+    pick: ['wrongQuestions', 'likeList', 'userRecords']
   }
 })


### PR DESCRIPTION
## Why

PR #5 合并后，标记 / 收藏 / 错题三条信息流之间的关系并不干净：

- 上一版为了让 \"错题已推送至收藏夹\" 这个弹窗成立，`addWrongQuestion` 会同时写 `wrongQuestions` 和 `likeList`；`toggleFavorite` 取消收藏时再连带删除 `wrongQuestions`。看似自洽，但实际上意味着 \"我的收藏\" 里混进了所有错题，而用户的语义里收藏 ≠ 错题。
- 同时存在一个独立的 `markList` 做 \"标记\"，但它和错题本的概念基本重合：用户想要 \"打个记号回头看\"，本身就是错题本服务的目的。

## What

折成两条干净的列表：

| 概念 | 数据 | 写入 | UI 入口 |
|------|------|------|---------|
| 收藏 | `likeList` | 用户手动点星形按钮 | 题目卡右上角\"⭐收藏 / 已收藏\" |
| 错题 / 标记 | `wrongQuestions` | ① 在线练习答错自动写入 ② 用户手动点书签按钮 | 题目卡右上角\"🔖标记 / 已标记\" |

具体改动 (`6c59918`):

- `src/stores/question.js`
  - 删 `markList` state 及 `addMarkQuestion` / `removeMarkQuestion` / `clearMarkList`
  - `isMarked` / `toggleMark` 直接读写 `wrongQuestions`
  - `addWrongQuestion` 不再镜像到 `likeList`
  - `toggleFavorite` 取消时只删 `likeList`，不再级联删除 `wrongQuestions`
  - `persist.pick` 删除 `'markList'`
- `src/components/examRecord.vue`
  - 提交弹窗 \"错题已推送至**收藏夹**\" → \"错题已推送至**错题本**\"，与代码实际行为一致
- `src/components/questionCard.vue`
  - 标记按钮 toast: \"已标记 / 已取消标记\" → \"已加入错题本 / 已从错题本移除\"
  - 按钮文字 \"标记 / 已标记\" 保留不变（视觉对称，配色继续与收藏按钮一致）

## 用户视角的可观察行为

- 在练习页或收藏夹页点 **书签按钮** → 进/出错题本，**不会**影响收藏夹
- 在练习页或收藏夹页点 **星形按钮** → 进/出收藏夹，**不会**影响错题本
- 在线练习答错的题 → 进错题本（在练习页和收藏夹的\"错题\"标签里都会显示书签按钮已激活）
- 收藏夹的 \"我的收藏\" 标签只显示用户手动收藏过的；\"错题\" 标签显示错题；\"全部\" 是并集
- localStorage 持久化字段：`wrongQuestions / likeList / userRecords`（不再有 `markList`）