### PR TITLE
feat: 键盘快捷键 & refactor: 单题组件

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,12 +1,11 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "esnext",
     "module": "esnext",
-    "baseUrl": "./",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "paths": {
       "@/*": [
-        "src/*"
+        "./src/*"
       ]
     },
     "lib": [

--- a/src/components/QuestionItem.vue
+++ b/src/components/QuestionItem.vue
@@ -1,0 +1,432 @@
+<script setup>
+// 用一份模板按题型 computed 分支替代原来四段重复块
+// 用一份模板按题型 computed 分支进对应题型
+// 所有数据经 props 传入，交互经 emit 上抛，没有逻辑修改
+import { ref, computed, watch } from 'vue'
+import { getQuestionType, TYPE_LABEL } from '@/utils/questionType'
+
+const props = defineProps({
+  question: { type: Object, required: true },
+  seq: { type: Number, required: true },
+  practiceMode: { type: Boolean, default: false },
+  showAnswer: { type: Boolean, default: false },
+  practiceResult: { type: Object, default: null },
+  practiceAnswer: { type: [String, Array], default: null },
+  isFav: { type: Boolean, default: false },
+  isMarked: { type: Boolean, default: false },
+  isFavoritesView: { type: Boolean, default: false },
+  subjectLabel: { type: String, default: '' }
+})
+
+const emit = defineEmits(['toggle-answer', 'toggle-fav', 'toggle-mark', 'submit-practice'])
+
+const options = ['A', 'B', 'C', 'D', 'E']
+const type = computed(() => getQuestionType(props.question))
+
+// 练习输入本地状态：初始/回填自 practiceAnswer prop（父组件仍按下标存储）
+const localChoice = ref(typeof props.practiceAnswer === 'string' ? props.practiceAnswer : null) // 判断/单选
+const localMulti = ref(Array.isArray(props.practiceAnswer) ? [...props.practiceAnswer] : [])      // 多选
+const localFill = ref(typeof props.practiceAnswer === 'string' ? props.practiceAnswer : '')       // 填空
+
+// 父组件重置 practiceAnswers（练习模式切换/路由切换）时，同步清空本地输入
+watch(() => props.practiceAnswer, (val) => {
+  localChoice.value = typeof val === 'string' ? val : null
+  localMulti.value = Array.isArray(val) ? [...val] : []
+  localFill.value = typeof val === 'string' ? val : ''
+})
+
+const onChoiceChange = (val) => emit('submit-practice', val)
+const submitFill = () => emit('submit-practice', localFill.value)
+const submitMulti = () => emit('submit-practice', localMulti.value)
+</script>
+
+<template>
+  <div class="typeCover">
+    <div class="questionTypeCover">
+      <div class="left">
+        <span class="seq">{{ seq }}</span>
+      </div>
+      <div class="right">
+        <div class="markAndLike">
+          <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked }" @click="emit('toggle-mark')" type="button">
+            <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
+              <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
+                :fill="isMarked ? 'currentColor' : 'none'"
+                stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+            </svg>
+            <span class="fav-text">{{ isMarked ? '已标记' : '标记' }}</span>
+          </button>
+          <button class="fav-btn" :class="{ 'is-fav': isFav }" @click="emit('toggle-fav')" type="button">
+            <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
+              <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
+                :fill="isFav ? 'currentColor' : 'none'"
+                stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
+            </svg>
+            <span class="fav-text">{{ isFav ? '已收藏' : '收藏' }}</span>
+          </button>
+        </div>
+        <div class="questionType">
+          <span v-if="isFavoritesView">{{ subjectLabel }} - </span>
+          <span>{{ TYPE_LABEL[type] }}</span>
+        </div>
+        <div class="questionStem">{{ question.questionStem }}</div>
+
+        <!-- 练习模式：判断题 -->
+        <div class="practice-area" v-if="practiceMode && type === 'rightWrong' && !practiceResult">
+          <el-radio-group v-model="localChoice" @change="onChoiceChange">
+            <el-radio v-for="(opt, k) in question.option" :key="k" :label="opt">{{ opt }}</el-radio>
+          </el-radio-group>
+        </div>
+
+        <!-- 练习模式：填空题 -->
+        <div class="practice-area" v-if="practiceMode && type === 'fillingBlank' && !practiceResult">
+          <div class="fill-practice-row">
+            <el-input v-model="localFill" placeholder="请输入答案" class="fill-input"
+              @keyup.enter.native="submitFill"></el-input>
+            <el-button type="primary" size="small" @click="submitFill" class="fill-submit">提交</el-button>
+          </div>
+        </div>
+
+        <!-- 练习模式：单选题 -->
+        <div class="practice-area" v-if="practiceMode && type === 'singleChoice'">
+          <el-radio-group v-model="localChoice" @change="onChoiceChange" :disabled="!!practiceResult">
+            <div v-for="(opt, k) in question.option" :key="k" class="practice-option">
+              <el-radio :label="options[k]">{{ options[k] }}、{{ opt }}</el-radio>
+            </div>
+          </el-radio-group>
+        </div>
+
+        <!-- 练习模式：多选题 -->
+        <div class="practice-area" v-if="practiceMode && type === 'multipleChoice'">
+          <el-checkbox-group v-model="localMulti" :disabled="!!practiceResult">
+            <div v-for="(opt, k) in question.option" :key="k" class="practice-option">
+              <el-checkbox :label="options[k]">{{ options[k] }}、{{ opt }}</el-checkbox>
+            </div>
+          </el-checkbox-group>
+          <el-button v-if="!practiceResult" type="primary" size="small" @click="submitMulti"
+            :disabled="!localMulti || localMulti.length === 0" class="multi-submit">确认提交</el-button>
+        </div>
+
+        <!-- 普通模式选项（单选/多选） -->
+        <div class="questionOpt" v-if="!practiceMode && (type === 'singleChoice' || type === 'multipleChoice')">
+          <div class="option" v-for="(opt, k) in question.option" :key="k">
+            <div class="dot"></div>
+            <div class="optText">{{ options[k] }}、{{ question.option[k] }}</div>
+          </div>
+        </div>
+
+        <!-- 练习结果（所有题型） -->
+        <div class="practice-result" v-if="practiceMode && practiceResult">
+          <span class="result-tag" :class="practiceResult.isCorrect ? 'result-true' : 'result-false'">
+            {{ practiceResult.isCorrect ? '回答正确' : '回答错误' }}
+          </span>
+          <span class="your-answer">你的答案：{{ practiceResult.userAnswer }}</span>
+          <span class="correctAnswer" v-if="!practiceResult.isCorrect">正确答案：{{ question.answer }}</span>
+        </div>
+
+        <!-- 普通模式答案：判断题 -->
+        <div class="questionAnswer" v-if="!practiceMode && type === 'rightWrong'">
+          <span class="colorBefore"></span>
+          <span class="correctAnswer">正确答案：</span>
+          <span class="true" @click="emit('toggle-answer')" v-if="question.answer == '正确'">{{ showAnswer ? question.answer : '' }}</span>
+          <span class="false" @click="emit('toggle-answer')" v-if="question.answer == '错误'">{{ showAnswer ? question.answer : '' }}</span>
+          <span class="answer" @click="emit('toggle-answer')" v-if="!showAnswer">点击显示答案</span>
+        </div>
+
+        <!-- 普通模式答案：其余题型 -->
+        <div class="questionAnswer" v-if="!practiceMode && type !== 'rightWrong'">
+          <span class="colorBefore"></span>
+          <span class="correctAnswer">正确答案：</span>
+          <span class="answer" @click="emit('toggle-answer')">{{ showAnswer ? question.answer : '点击显示答案' }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</template>
+
+<style lang="scss">
+.fade-enter-active,
+.fade-leave-active {
+  transition: opacity 0.15s;
+}
+
+.fade-enter,
+.fade-leave-to {
+  opacity: 0;
+}
+
+.typeCover {
+  .questionTypeCover {
+    font-family: HarmonyOS Sans SC;
+    display: flex;
+    justify-content: flex-start;
+
+    .left {
+      width: fit-content;
+      margin-right: 10px;
+
+      .seq {
+        height: 30px;
+        font-size: 20px;
+        font-weight: bold;
+        color: white;
+        background-color: #6C5DD3;
+        border-radius: 10px;
+        padding: 0px 10px;
+        line-height: 30px;
+        display: inline-block;
+      }
+    }
+
+    .right {
+      text-align: left;
+      position: relative;
+      width: 94%;
+
+      .markAndLike {
+        height: 32px;
+        position: absolute;
+        top: 0px;
+        right: 0px;
+        display: flex;
+        align-items: center;
+        gap: 8px;
+
+        .fav-btn {
+          display: inline-flex;
+          align-items: center;
+          gap: 4px;
+          height: 28px;
+          padding: 0 10px;
+          border-radius: 14px;
+          border: 1px solid #6C5DD3;
+          background-color: #fff;
+          color: #6C5DD3;
+          font-size: 13px;
+          font-weight: 600;
+          cursor: pointer;
+          transition: all 0.2s ease;
+          line-height: 1;
+          font-family: inherit;
+
+          .fav-icon {
+            flex-shrink: 0;
+            transition: transform 0.2s ease;
+          }
+
+          .fav-text {
+            white-space: nowrap;
+          }
+
+          &:hover {
+            background-color: #E6E4F4;
+            transform: translateY(-1px);
+            box-shadow: 0 2px 6px rgba(108, 93, 211, 0.25);
+          }
+
+          &:active .fav-icon {
+            transform: scale(1.2);
+          }
+
+          &.is-fav {
+            background-color: #6C5DD3;
+            color: #fff;
+            border-color: #6C5DD3;
+
+            .fav-icon {
+              // Drop shadow gives the star a faint outline so the filled
+              // glyph stays visible even though fill === button background.
+              filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.35));
+            }
+
+            &:hover {
+              background-color: #5B4FB5;
+              border-color: #5B4FB5;
+            }
+          }
+        }
+      }
+
+      .questionType {
+        letter-spacing: 3px;
+        height: 30px;
+        line-height: 30px;
+        font-size: 18px;
+        font-weight: bold;
+        color: #877BD1;
+        margin-bottom: 10px;
+      }
+
+      .questionStem {
+        font-weight: 500;
+        letter-spacing: 1px;
+        font-size: 18px;
+        margin-bottom: 4px;
+        line-height: 30px;
+      }
+
+      .questionOpt {
+        .option {
+          display: flex;
+          align-items: flex-start;
+          line-height: 28px;
+          font-size: 18px;
+          letter-spacing: 1px;
+          position: relative;
+          text-align: left;
+          margin-bottom: 4px;
+
+          .dot {
+            flex: 0 0 auto;
+            width: 14px;
+            height: 14px;
+            border-radius: 50%;
+            background-color: #6C5DD3;
+            margin-top: 7px;
+          }
+
+          .optText {
+            flex: 1;
+            margin-left: 8px;
+            text-indent: 0;
+            word-break: break-word;
+          }
+        }
+      }
+
+      .questionAnswer {
+        letter-spacing: 1px;
+        height: 30px;
+        line-height: 30px;
+        margin-top: 18px;
+        display: flex;
+        justify-content: flex-start;
+        margin-bottom: 10px;
+
+        .colorBefore {
+          background-color: #6C5DD3;
+          width: 8px;
+          height: 30px;
+          display: inline-block;
+          border-radius: 4px;
+          margin-right: 4px;
+        }
+
+        .correctAnswer {
+          color: #707070;
+          display: inline-block;
+          height: 30px;
+          line-height: 30px;
+          font-size: 18px;
+        }
+
+        .false {
+          color: #FF3B3B;
+          display: inline-block;
+          height: 30px;
+          line-height: 30px;
+          font-size: 18px;
+        }
+
+        .true {
+          color: #0BDE00;
+          display: inline-block;
+          height: 30px;
+          line-height: 30px;
+          font-size: 18px;
+        }
+
+        .answer {
+          display: inline-block;
+          height: 30px;
+          line-height: 30px;
+          font-size: 18px;
+          color: #5F89D3;
+        }
+      }
+    }
+  }
+
+  .practice-area {
+    margin: 10px 0;
+
+    .practice-option {
+      margin-bottom: 8px;
+      line-height: 28px;
+      font-size: 16px;
+      text-align: left;
+
+      .el-radio,
+      .el-checkbox {
+        display: flex;
+        align-items: flex-start;
+        height: auto;
+        white-space: normal;
+      }
+
+      .el-radio__input,
+      .el-checkbox__input {
+        flex: 0 0 auto;
+        margin-top: 4px;
+      }
+
+      .el-radio__label,
+      .el-checkbox__label {
+        display: block;
+        flex: 1;
+        white-space: normal;
+        line-height: 24px;
+        text-align: left;
+        word-break: break-word;
+      }
+    }
+
+    .fill-practice-row {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+
+      .fill-input {
+        max-width: 300px;
+      }
+    }
+
+    .multi-submit {
+      margin-top: 8px;
+    }
+  }
+
+  .practice-result {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    margin: 10px 0;
+    font-size: 16px;
+
+    .result-tag {
+      font-weight: bold;
+      padding: 2px 10px;
+      border-radius: 6px;
+    }
+
+    .result-true {
+      color: #0BDE00;
+      background: #f0fff0;
+    }
+
+    .result-false {
+      color: #FF3B3B;
+      background: #fff0f0;
+    }
+
+    .your-answer {
+      color: #707070;
+    }
+
+    .correctAnswer {
+      color: #5F89D3;
+      font-weight: 500;
+    }
+  }
+}
+</style>

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -53,7 +53,7 @@
       <div v-if="showList == '' && onSearch">
         <el-empty description="搜索结果为空"></el-empty>
       </div>
-      <div class="questionCover" v-for="(item, i) in showList" :key="i"
+      <div class="questionCover" v-for="(item, i) in showList" :key="i" :id="'qcard-' + i"
         @mouseenter="hoveredIndex = i" @mouseleave="hoveredIndex = null">
         <!-- 判断题 -->
         <div class="typeCover" v-if="showList[i].option.length == 2">
@@ -335,6 +335,7 @@ export default {
     return {
       showAnswers: [],
       hoveredIndex: null,  // 鼠标当前悬浮的题目序号，用于快捷键显示答案
+      currentIndex: -1,  // 键盘导航定位的题目序号（滚动到顶端的那道），用于 -/=/0 快捷键
       showAllAnswers: false,
       defaultShowAnswer: false,
       subjectFocus: [],
@@ -445,11 +446,12 @@ export default {
     }
     // 初始化所有题目的显示状态
     this.initShowAnswers();
-    // 快捷键：按 q 显示/隐藏鼠标悬浮题目的答案
+    // 快捷键：q 切换鼠标悬浮题目答案；- 上一题 / = 下一题 / 0 切换当前题答案（右手单手操作）
     window.addEventListener('keydown', this.handleHotkey);
   },
   beforeUnmount() {
     window.removeEventListener('keydown', this.handleHotkey);
+    if (this._suppressTimer) clearTimeout(this._suppressTimer);
   },
   async created() {
     this.lesson = this.$route.params.lesson;
@@ -551,6 +553,8 @@ export default {
   },
   methods: {
     initShowAnswers() {
+      // 列表重建时，键盘导航定位回到未定位状态
+      this.currentIndex = -1;
       // Try to restore from localStorage
       const storageKey = this.getAnswerStorageKey();
       let saved = {};
@@ -587,13 +591,70 @@ export default {
       this.saveViewedState();
     },
     handleHotkey(e) {
-      if (e.key !== 'q' && e.key !== 'Q') return;
       // 在输入框/搜索框里打字时不触发
       const tag = e.target.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
-      // 没有悬浮在任何题目上则忽略
-      if (this.hoveredIndex === null) return;
-      this.toggleAnswer(this.hoveredIndex);
+      // 保留浏览器自身的快捷键（如 Ctrl+= 放大、Ctrl+- 缩小）
+      if (e.ctrlKey || e.metaKey || e.altKey) return;
+
+      // q：切换鼠标悬浮题目的答案
+      if (e.key === 'q' || e.key === 'Q') {
+        if (this.hoveredIndex === null) return;
+        this.toggleAnswer(this.hoveredIndex);
+        return;
+      }
+
+      // 右手三连键：- 上一题 / = 下一题 / 0 切换当前题答案
+      if (e.key === '-' || e.key === '=' || e.key === '0') {
+        if (!this.showList.length) return;
+        e.preventDefault();
+        // 以页面顶端（0 像素处）的题目为“当前题”，使鼠标滚动也能更新题号。
+        // 键盘平滑滚动期间（suppress 标记）保留乐观题号，以支持连续按键。
+        if (!this._suppressScrollSync) {
+          this.currentIndex = this.getTopIndex();
+        }
+        if (e.key === '=') {
+          this.goToQuestion(this.currentIndex + 1);
+        } else if (e.key === '-') {
+          // 尚未定位时按上一题，先落到第一题
+          this.goToQuestion(this.currentIndex < 0 ? 0 : this.currentIndex - 1);
+        } else if (e.key === '0') {
+          const idx = this.currentIndex < 0 ? 0 : this.currentIndex;
+          this.currentIndex = idx;
+          this.toggleAnswer(idx);
+        }
+      }
+    },
+    // 找到当前占据视口顶端的题目序号。
+    // 用「bottom 仍在顶端线下方」判断，而非「top ≈ 0」：因为题卡有
+    // scroll-margin-top，滚动定位后当前题 top 会停在 ~16px，用 top 判断会偏到上一题。
+    // bottom 离判定边界很远，可避免亚像素 / scroll-margin 造成的 off-by-one。
+    getTopIndex() {
+      const n = this.showList.length;
+      if (!n) return -1;
+      const offset = 2; // 顶端线容差：略大于 0，跳过仅剩几像素即将划出的上一题
+      for (let i = 0; i < n; i++) {
+        const el = document.getElementById('qcard-' + i);
+        if (!el) continue;
+        // 第一道「底部尚未划出顶端线」的题，即为占据顶端的当前题
+        if (el.getBoundingClientRect().bottom > offset) return i;
+      }
+      return n - 1; // 已滚到底部，最后一题为当前题
+    },
+    goToQuestion(index) {
+      const clamped = Math.max(0, Math.min(index, this.showList.length - 1));
+      this.currentIndex = clamped;
+      // 平滑滚动动画期间暂停“按滚动位置同步题号”，避免中间帧覆盖目标题号，
+      // 从而支持快速连按 -/= 连续翻题。
+      this._suppressScrollSync = true;
+      if (this._suppressTimer) clearTimeout(this._suppressTimer);
+      this._suppressTimer = setTimeout(() => {
+        this._suppressScrollSync = false;
+      }, 500);
+      this.$nextTick(() => {
+        const el = document.getElementById('qcard-' + clamped);
+        if (el) el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      });
     },
     updateDefaultSetting() {
       this.defaultShowAnswer = !this.defaultShowAnswer
@@ -741,6 +802,7 @@ export default {
       if (this.searchWord === "") {
         this.showList = [...this.list]
         this.onSearch = false
+        this.currentIndex = -1
       }
     },
     search() {
@@ -751,6 +813,7 @@ export default {
       let temp = this.searchWord ? fuse.search(this.searchWord).map(result => result.item) : this.list;
       this.showList = [...temp]
       this.onSearch = this.searchWord === "" ? false : true
+      this.currentIndex = -1
     }
   }
 }
@@ -812,6 +875,7 @@ export default {
     padding: 14px 18px;
     margin: 15px 34px;
     border-radius: 24px;
+    scroll-margin-top: 16px;  // 键盘 -/= 滚动定位时，与视口顶端留出空隙
     box-shadow: 0px -1px 8px 0px rgba(230, 232, 240, 0.9),
       -1px 0px 8px 0px rgba(230, 232, 240, 0.9),
       1px 0px 8px 0px rgba(230, 232, 240, 0.9),

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -55,265 +55,19 @@
       </div>
       <div class="questionCover" v-for="(item, i) in showList" :key="i" :id="'qcard-' + i"
         @mouseenter="hoveredIndex = i" @mouseleave="hoveredIndex = null">
-        <!-- 判断题 -->
-        <div class="typeCover" v-if="showList[i].option.length == 2">
-          <div class="questionTypeCover">
-            <div class="left">
-              <span class="seq">{{ i + 1 }}</span>
-            </div>
-            <div class="right">
-              <div class="markAndLike">
-                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
-                  @click="toggleMark(showList[i])" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
-                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
-                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
-                </button>
-                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
-                  @click="toggleFav(showList[i], i)" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
-                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
-                </button>
-              </div>
-              <div class="questionType">
-                <span v-if="$route.path == '/newHome/favorites'">
-                  {{ abbreviationSubjectList[showList[i].abbreviationSubject] }} -
-                </span>
-                <span>判断</span>
-              </div>
-              <div class="questionStem">{{ showList[i].questionStem }}</div>
-              <!-- 练习模式：判断题选择 -->
-              <div class="practice-area" v-if="practiceMode && !practiceResults[i]">
-                <el-radio-group v-model="practiceAnswers[i]" @change="val => submitPractice(i, val)">
-                  <el-radio v-for="(opt, k) in showList[i].option" :key="k" :label="opt">{{ opt }}</el-radio>
-                </el-radio-group>
-              </div>
-              <!-- 练习结果 -->
-              <div class="practice-result" v-if="practiceMode && practiceResults[i]">
-                <span class="result-tag" :class="practiceResults[i].isCorrect ? 'result-true' : 'result-false'">
-                  {{ practiceResults[i].isCorrect ? '回答正确' : '回答错误' }}
-                </span>
-                <span class="your-answer">你的答案：{{ practiceResults[i].userAnswer }}</span>
-                <span class="correctAnswer" v-if="!practiceResults[i].isCorrect">正确答案：{{ showList[i].answer }}</span>
-              </div>
-              <!-- 普通模式答案 -->
-              <div class="questionAnswer" v-if="!practiceMode">
-                <span class="colorBefore"></span>
-                <span class="correctAnswer">正确答案：</span>
-                <span class="true" @click="toggleAnswer(i)" v-if="showList[i].answer == '正确'">{{ showAnswers[i] ?
-                  showList[i].answer : '' }}</span>
-                <span class="false" @click="toggleAnswer(i)" v-if="showList[i].answer == '错误'">{{ showAnswers[i] ?
-                  showList[i].answer : '' }}</span>
-                <span class="answer" @click="toggleAnswer(i)" v-if="!showAnswers[i]">点击显示答案</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- 填空题 -->
-        <div class="typeCover" v-if="showList[i].option == ''">
-          <div class="questionTypeCover">
-            <div class="left">
-              <span class="seq">{{ i + 1 }}</span>
-            </div>
-            <div class="right">
-              <div class="markAndLike">
-                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
-                  @click="toggleMark(showList[i])" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
-                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
-                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
-                </button>
-                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
-                  @click="toggleFav(showList[i], i)" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
-                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
-                </button>
-              </div>
-              <div class="questionType">
-                <span v-if="$route.path == '/newHome/favorites'">
-                  {{ abbreviationSubjectList[showList[i].abbreviationSubject] }} -
-                </span>
-                <span>填空</span>
-              </div>
-              <div class="questionStem">{{ showList[i].questionStem }}</div>
-              <!-- 练习模式：填空题输入 -->
-              <div class="practice-area" v-if="practiceMode && !practiceResults[i]">
-                <div class="fill-practice-row">
-                  <el-input v-model="practiceAnswers[i]" placeholder="请输入答案" class="fill-input"
-                    @keyup.enter.native="submitPractice(i, practiceAnswers[i])"></el-input>
-                  <el-button type="primary" size="small" @click="submitPractice(i, practiceAnswers[i])"
-                    class="fill-submit">提交</el-button>
-                </div>
-              </div>
-              <!-- 练习结果 -->
-              <div class="practice-result" v-if="practiceMode && practiceResults[i]">
-                <span class="result-tag" :class="practiceResults[i].isCorrect ? 'result-true' : 'result-false'">
-                  {{ practiceResults[i].isCorrect ? '回答正确' : '回答错误' }}
-                </span>
-                <span class="your-answer">你的答案：{{ practiceResults[i].userAnswer }}</span>
-                <span class="correctAnswer" v-if="!practiceResults[i].isCorrect">正确答案：{{ showList[i].answer }}</span>
-              </div>
-              <!-- 普通模式答案 -->
-              <div class="questionAnswer" v-if="!practiceMode">
-                <span class="colorBefore"></span>
-                <span class="correctAnswer">正确答案：</span>
-                <span class="answer" @click="toggleAnswer(i)">{{ showAnswers[i] ? showList[i].answer : '点击显示答案'
-                  }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- 单选题 -->
-        <div class="typeCover" v-if="showList[i].option.length == 4 && showList[i].answer.length == 1">
-          <div class="questionTypeCover">
-            <div class="left">
-              <span class="seq">{{ i + 1 }}</span>
-            </div>
-            <div class="right">
-              <div class="markAndLike">
-                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
-                  @click="toggleMark(showList[i])" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
-                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
-                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
-                </button>
-                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
-                  @click="toggleFav(showList[i], i)" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
-                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
-                </button>
-              </div>
-              <div class="questionType">
-                <span v-if="$route.path == '/newHome/favorites'">
-                  {{ abbreviationSubjectList[showList[i].abbreviationSubject] }} -
-                </span>
-                <span>单选</span>
-              </div>
-              <div class="questionStem">{{ showList[i].questionStem }}</div>
-              <!-- 练习模式：单选题选择 -->
-              <div class="practice-area" v-if="practiceMode">
-                <el-radio-group v-model="practiceAnswers[i]" @change="val => submitPractice(i, val)"
-                  :disabled="!!practiceResults[i]">
-                  <div v-for="(opt, k) in showList[i].option" :key="k" class="practice-option">
-                    <el-radio :label="options[k]">{{ options[k] }}、{{ opt }}</el-radio>
-                  </div>
-                </el-radio-group>
-              </div>
-              <!-- 普通模式选项 -->
-              <div class="questionOpt" v-if="!practiceMode">
-                <div class="option" v-for="(item, k) in showList[i].option" :key="k">
-                  <div class="dot"></div>
-                  <div class="optText">{{ options[k] }}、{{ showList[i].option[k] }}</div>
-                </div>
-              </div>
-              <!-- 练习结果 -->
-              <div class="practice-result" v-if="practiceMode && practiceResults[i]">
-                <span class="result-tag" :class="practiceResults[i].isCorrect ? 'result-true' : 'result-false'">
-                  {{ practiceResults[i].isCorrect ? '回答正确' : '回答错误' }}
-                </span>
-                <span class="your-answer">你的答案：{{ practiceResults[i].userAnswer }}</span>
-                <span class="correctAnswer" v-if="!practiceResults[i].isCorrect">正确答案：{{ showList[i].answer }}</span>
-              </div>
-              <!-- 普通模式答案 -->
-              <div class="questionAnswer" v-if="!practiceMode">
-                <span class="colorBefore"></span>
-                <span class="correctAnswer">正确答案：</span>
-                <span class="answer" @click="toggleAnswer(i)">{{ showAnswers[i] ? showList[i].answer : '点击显示答案'
-                  }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
-        <!-- 多选题 -->
-        <div class="typeCover" v-if="showList[i].option.length > 3 && showList[i].answer.length > 1">
-          <div class="questionTypeCover">
-            <div class="left">
-              <span class="seq">{{ i + 1 }}</span>
-            </div>
-            <div class="right">
-              <div class="markAndLike">
-                <button class="fav-btn mark-btn" :class="{ 'is-fav': isMarked(showList[i]) }"
-                  @click="toggleMark(showList[i])" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="14" height="14" aria-hidden="true">
-                    <path d="M7 3h10a1 1 0 0 1 1 1v17l-6-3.5L6 21V4a1 1 0 0 1 1-1z"
-                      :fill="isMarked(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isMarked(showList[i]) ? '已标记' : '标记' }}</span>
-                </button>
-                <button class="fav-btn" :class="{ 'is-fav': isFav(showList[i]) }"
-                  @click="toggleFav(showList[i], i)" type="button">
-                  <svg class="fav-icon" viewBox="0 0 24 24" width="16" height="16" aria-hidden="true">
-                    <path d="M12 2.5l2.95 6.36 6.55.66-4.9 4.79 1.39 6.69L12 17.77l-6 3.23 1.39-6.69L2.5 9.52l6.55-.66L12 2.5z"
-                      :fill="isFav(showList[i]) ? 'currentColor' : 'none'"
-                      stroke="currentColor" stroke-width="1.6" stroke-linejoin="round"/>
-                  </svg>
-                  <span class="fav-text">{{ isFav(showList[i]) ? '已收藏' : '收藏' }}</span>
-                </button>
-              </div>
-              <div class="questionType">
-                <span v-if="$route.path == '/newHome/favorites'">
-                  {{ abbreviationSubjectList[showList[i].abbreviationSubject] }} -
-                </span>
-                <span>多选</span>
-              </div>
-              <div class="questionStem">{{ showList[i].questionStem }}</div>
-              <!-- 练习模式：多选题选择 -->
-              <div class="practice-area" v-if="practiceMode">
-                <el-checkbox-group v-model="practiceAnswers[i]" :disabled="!!practiceResults[i]">
-                  <div v-for="(opt, k) in showList[i].option" :key="k" class="practice-option">
-                    <el-checkbox :label="options[k]">{{ options[k] }}、{{ opt }}</el-checkbox>
-                  </div>
-                </el-checkbox-group>
-                <el-button v-if="!practiceResults[i]" type="primary" size="small" @click="submitPractice(i, practiceAnswers[i])"
-                  :disabled="!practiceAnswers[i] || practiceAnswers[i].length === 0" class="multi-submit">确认提交</el-button>
-              </div>
-              <!-- 普通模式选项 -->
-              <div class="questionOpt" v-if="!practiceMode">
-                <div class="option" v-for="(item, k) in showList[i].option" :key="k">
-                  <div class="dot"></div>
-                  <div class="optText">{{ options[k] }}、{{ showList[i].option[k] }}</div>
-                </div>
-              </div>
-              <!-- 练习结果 -->
-              <div class="practice-result" v-if="practiceMode && practiceResults[i]">
-                <span class="result-tag" :class="practiceResults[i].isCorrect ? 'result-true' : 'result-false'">
-                  {{ practiceResults[i].isCorrect ? '回答正确' : '回答错误' }}
-                </span>
-                <span class="your-answer">你的答案：{{ practiceResults[i].userAnswer }}</span>
-                <span class="correctAnswer" v-if="!practiceResults[i].isCorrect">正确答案：{{ showList[i].answer }}</span>
-              </div>
-              <!-- 普通模式答案 -->
-              <div class="questionAnswer" v-if="!practiceMode">
-                <span class="colorBefore"></span>
-                <span class="correctAnswer">正确答案：</span>
-                <span class="answer" @click="toggleAnswer(i)">{{ showAnswers[i] ? showList[i].answer : '点击显示答案'
-                  }}</span>
-              </div>
-            </div>
-          </div>
-        </div>
+        <QuestionItem
+          :question="item" :seq="i + 1"
+          :practice-mode="practiceMode"
+          :show-answer="showAnswers[i]"
+          :practice-result="practiceResults[i] || null"
+          :practice-answer="practiceAnswers[i]"
+          :is-fav="isFav(item)" :is-marked="isMarked(item)"
+          :is-favorites-view="$route.path === '/newHome/favorites'"
+          :subject-label="abbreviationSubjectList[item.abbreviationSubject]"
+          @toggle-answer="toggleAnswer(i)"
+          @toggle-fav="toggleFav(item, i)"
+          @toggle-mark="toggleMark(item)"
+          @submit-practice="val => submitPractice(i, val)" />
       </div>
       <div class="bottomAlert" v-if="showList.length !== 0">--- 已经到底啦 ---</div>
     </div>
@@ -326,8 +80,11 @@ import { loadQuestionBank } from '@/utils/loadJson'
 import Fuse from 'fuse.js';
 import { makePdf } from "@/utils/makePdf";
 import { ElMessage } from 'element-plus'
+import QuestionItem from '@/components/QuestionItem.vue'
+import { getQuestionType } from '@/utils/questionType'
 
 export default {
+  components: { QuestionItem },
   setup() {
     return { store: useQuestionStore() }
   },
@@ -591,10 +348,8 @@ export default {
       this.saveViewedState();
     },
     handleHotkey(e) {
-      // 在输入框/搜索框里打字时不触发
       const tag = e.target.tagName;
       if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
-      // 保留浏览器自身的快捷键（如 Ctrl+= 放大、Ctrl+- 缩小）
       if (e.ctrlKey || e.metaKey || e.altKey) return;
 
       // q：切换鼠标悬浮题目的答案
@@ -608,15 +363,13 @@ export default {
       if (e.key === '-' || e.key === '=' || e.key === '0') {
         if (!this.showList.length) return;
         e.preventDefault();
-        // 以页面顶端（0 像素处）的题目为“当前题”，使鼠标滚动也能更新题号。
-        // 键盘平滑滚动期间（suppress 标记）保留乐观题号，以支持连续按键。
+        // 以页面顶端的题目为“当前题”，滚动期间保留乐观题号
         if (!this._suppressScrollSync) {
           this.currentIndex = this.getTopIndex();
         }
         if (e.key === '=') {
           this.goToQuestion(this.currentIndex + 1);
         } else if (e.key === '-') {
-          // 尚未定位时按上一题，先落到第一题
           this.goToQuestion(this.currentIndex < 0 ? 0 : this.currentIndex - 1);
         } else if (e.key === '0') {
           const idx = this.currentIndex < 0 ? 0 : this.currentIndex;
@@ -625,27 +378,21 @@ export default {
         }
       }
     },
-    // 找到当前占据视口顶端的题目序号。
-    // 用「bottom 仍在顶端线下方」判断，而非「top ≈ 0」：因为题卡有
-    // scroll-margin-top，滚动定位后当前题 top 会停在 ~16px，用 top 判断会偏到上一题。
-    // bottom 离判定边界很远，可避免亚像素 / scroll-margin 造成的 off-by-one。
+    // 因为题卡有scroll-margin-top，滚动定位后当前题 top 会停在 ~16px，用 top 判断会偏到上一题。
     getTopIndex() {
       const n = this.showList.length;
       if (!n) return -1;
-      const offset = 2; // 顶端线容差：略大于 0，跳过仅剩几像素即将划出的上一题
+      const offset = 2;
       for (let i = 0; i < n; i++) {
         const el = document.getElementById('qcard-' + i);
         if (!el) continue;
-        // 第一道「底部尚未划出顶端线」的题，即为占据顶端的当前题
         if (el.getBoundingClientRect().bottom > offset) return i;
       }
-      return n - 1; // 已滚到底部，最后一题为当前题
+      return n - 1;
     },
     goToQuestion(index) {
       const clamped = Math.max(0, Math.min(index, this.showList.length - 1));
       this.currentIndex = clamped;
-      // 平滑滚动动画期间暂停“按滚动位置同步题号”，避免中间帧覆盖目标题号，
-      // 从而支持快速连按 -/= 连续翻题。
       this._suppressScrollSync = true;
       if (this._suppressTimer) clearTimeout(this._suppressTimer);
       this._suppressTimer = setTimeout(() => {
@@ -662,26 +409,13 @@ export default {
       this.initShowAnswers();
       this.saveViewedState();
     },
-    getQuestionType(question) {
-      const { option, answer } = question;
-      if (!option || option.length === 0) {
-        return "fillingBlank"; // 填空题
-      } else if (option.length === 2) {
-        return "rightWrong"; // 判断题
-      } else if (answer.length === 1) {
-        return "singleChoice"; // 单选题
-      } else if (answer.length > 1) {
-        return "multipleChoice"; // 多选题
-      }
-      return null; // 未知题型
-    },
     updateShowList(type, checked) {
       const validSelectedTypes = Array.isArray(this.selectedTypes) ? this.selectedTypes : [];
       const validSelectedSubjects = Array.isArray(this.subjectFocus) ? this.subjectFocus : [];
 
       // 筛选题目：题型和科目取交集
       const filteredByType = validSelectedTypes.length
-        ? this.list.filter((question) => validSelectedTypes.includes(this.getQuestionType(question)))
+        ? this.list.filter((question) => validSelectedTypes.includes(getQuestionType(question)))
         : this.list; // 若未选择题型，保留所有题型
 
       const filteredBySubject = validSelectedSubjects.length
@@ -724,7 +458,7 @@ export default {
     },
     submitPractice(index, userAnswer) {
       const question = this.showList[index];
-      const qType = this.getQuestionType(question);
+      const qType = getQuestionType(question);
       let isCorrect = false;
 
       if (qType === 'singleChoice' || qType === 'rightWrong') {
@@ -880,197 +614,6 @@ export default {
       -1px 0px 8px 0px rgba(230, 232, 240, 0.9),
       1px 0px 8px 0px rgba(230, 232, 240, 0.9),
       0px 1px 8px 0px rgba(230, 232, 240, 0.9);
-
-    .questionTypeCover {
-      font-family: HarmonyOS Sans SC;
-      display: flex;
-      justify-content: flex-start;
-
-      .left {
-        width: fit-content;
-        margin-right: 10px;
-
-        .seq {
-          height: 30px;
-          font-size: 20px;
-          font-weight: bold;
-          color: white;
-          background-color: #6C5DD3;
-          border-radius: 10px;
-          padding: 0px 10px;
-          line-height: 30px;
-          display: inline-block;
-        }
-      }
-
-      .right {
-        text-align: left;
-        position: relative;
-        width: 94%;
-
-        .markAndLike {
-          height: 32px;
-          position: absolute;
-          top: 0px;
-          right: 0px;
-          display: flex;
-          align-items: center;
-          gap: 8px;
-
-          .fav-btn {
-            display: inline-flex;
-            align-items: center;
-            gap: 4px;
-            height: 28px;
-            padding: 0 10px;
-            border-radius: 14px;
-            border: 1px solid #6C5DD3;
-            background-color: #fff;
-            color: #6C5DD3;
-            font-size: 13px;
-            font-weight: 600;
-            cursor: pointer;
-            transition: all 0.2s ease;
-            line-height: 1;
-            font-family: inherit;
-
-            .fav-icon {
-              flex-shrink: 0;
-              transition: transform 0.2s ease;
-            }
-
-            .fav-text {
-              white-space: nowrap;
-            }
-
-            &:hover {
-              background-color: #E6E4F4;
-              transform: translateY(-1px);
-              box-shadow: 0 2px 6px rgba(108, 93, 211, 0.25);
-            }
-
-            &:active .fav-icon {
-              transform: scale(1.2);
-            }
-
-            &.is-fav {
-              background-color: #6C5DD3;
-              color: #fff;
-              border-color: #6C5DD3;
-
-              .fav-icon {
-                // Drop shadow gives the star a faint outline so the filled
-                // glyph stays visible even though fill === button background.
-                filter: drop-shadow(0 0 0.5px rgba(0, 0, 0, 0.35));
-              }
-
-              &:hover {
-                background-color: #5B4FB5;
-                border-color: #5B4FB5;
-              }
-            }
-          }
-        }
-
-        .questionType {
-          letter-spacing: 3px;
-          height: 30px;
-          line-height: 30px;
-          font-size: 18px;
-          font-weight: bold;
-          color: #877BD1;
-          margin-bottom: 10px;
-        }
-
-        .questionStem {
-          font-weight: 500;
-          letter-spacing: 1px;
-          font-size: 18px;
-          margin-bottom: 4px;
-          line-height: 30px;
-        }
-
-        .questionOpt {
-          .option {
-            display: flex;
-            align-items: flex-start;
-            line-height: 28px;
-            font-size: 18px;
-            letter-spacing: 1px;
-            position: relative;
-            text-align: left;
-            margin-bottom: 4px;
-
-            .dot {
-              flex: 0 0 auto;
-              width: 14px;
-              height: 14px;
-              border-radius: 50%;
-              background-color: #6C5DD3;
-              margin-top: 7px;
-            }
-
-            .optText {
-              flex: 1;
-              margin-left: 8px;
-              text-indent: 0;
-              word-break: break-word;
-            }
-          }
-        }
-
-        .questionAnswer {
-          letter-spacing: 1px;
-          height: 30px;
-          line-height: 30px;
-          margin-top: 18px;
-          display: flex;
-          justify-content: flex-start;
-          margin-bottom: 10px;
-
-          .colorBefore {
-            background-color: #6C5DD3;
-            width: 8px;
-            height: 30px;
-            display: inline-block;
-            border-radius: 4px;
-            margin-right: 4px;
-          }
-
-          .correctAnswer {
-            color: #707070;
-            display: inline-block;
-            height: 30px;
-            line-height: 30px;
-            font-size: 18px;
-          }
-
-          .false {
-            color: #FF3B3B;
-            display: inline-block;
-            height: 30px;
-            line-height: 30px;
-            font-size: 18px;
-          }
-
-          .true {
-            color: #0BDE00;
-            display: inline-block;
-            height: 30px;
-            line-height: 30px;
-            font-size: 18px;
-          }
-
-          .answer {
-            display: inline-block;
-            height: 30px;
-            line-height: 30px;
-            font-size: 18px;
-            color: #5F89D3;
-          }
-        }
-      }
-    }
   }
 
   .bottomAlert {
@@ -1085,88 +628,6 @@ export default {
   .practice-switch {
     margin-right: 12px;
     flex-shrink: 0;
-  }
-
-  .practice-area {
-    margin: 10px 0;
-
-    .practice-option {
-      margin-bottom: 8px;
-      line-height: 28px;
-      font-size: 16px;
-      text-align: left;
-
-      .el-radio,
-      .el-checkbox {
-        display: flex;
-        align-items: flex-start;
-        height: auto;
-        white-space: normal;
-      }
-
-      .el-radio__input,
-      .el-checkbox__input {
-        flex: 0 0 auto;
-        margin-top: 4px;
-      }
-
-      .el-radio__label,
-      .el-checkbox__label {
-        display: block;
-        flex: 1;
-        white-space: normal;
-        line-height: 24px;
-        text-align: left;
-        word-break: break-word;
-      }
-    }
-
-    .fill-practice-row {
-      display: flex;
-      align-items: center;
-      gap: 10px;
-
-      .fill-input {
-        max-width: 300px;
-      }
-    }
-
-    .multi-submit {
-      margin-top: 8px;
-    }
-  }
-
-  .practice-result {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    margin: 10px 0;
-    font-size: 16px;
-
-    .result-tag {
-      font-weight: bold;
-      padding: 2px 10px;
-      border-radius: 6px;
-    }
-
-    .result-true {
-      color: #0BDE00;
-      background: #f0fff0;
-    }
-
-    .result-false {
-      color: #FF3B3B;
-      background: #fff0f0;
-    }
-
-    .your-answer {
-      color: #707070;
-    }
-
-    .correctAnswer {
-      color: #5F89D3;
-      font-weight: 500;
-    }
   }
 }
 </style>

--- a/src/components/questionCard.vue
+++ b/src/components/questionCard.vue
@@ -53,7 +53,8 @@
       <div v-if="showList == '' && onSearch">
         <el-empty description="搜索结果为空"></el-empty>
       </div>
-      <div class="questionCover" v-for="(item, i) in showList" :key="i">
+      <div class="questionCover" v-for="(item, i) in showList" :key="i"
+        @mouseenter="hoveredIndex = i" @mouseleave="hoveredIndex = null">
         <!-- 判断题 -->
         <div class="typeCover" v-if="showList[i].option.length == 2">
           <div class="questionTypeCover">
@@ -333,6 +334,7 @@ export default {
   data() {
     return {
       showAnswers: [],
+      hoveredIndex: null,  // 鼠标当前悬浮的题目序号，用于快捷键显示答案
       showAllAnswers: false,
       defaultShowAnswer: false,
       subjectFocus: [],
@@ -443,6 +445,11 @@ export default {
     }
     // 初始化所有题目的显示状态
     this.initShowAnswers();
+    // 快捷键：按 q 显示/隐藏鼠标悬浮题目的答案
+    window.addEventListener('keydown', this.handleHotkey);
+  },
+  beforeUnmount() {
+    window.removeEventListener('keydown', this.handleHotkey);
   },
   async created() {
     this.lesson = this.$route.params.lesson;
@@ -578,6 +585,15 @@ export default {
       const newVal = !this.showAnswers[index];
       this.showAnswers.splice(index, 1, newVal);
       this.saveViewedState();
+    },
+    handleHotkey(e) {
+      if (e.key !== 'q' && e.key !== 'Q') return;
+      // 在输入框/搜索框里打字时不触发
+      const tag = e.target.tagName;
+      if (tag === 'INPUT' || tag === 'TEXTAREA' || e.target.isContentEditable) return;
+      // 没有悬浮在任何题目上则忽略
+      if (this.hoveredIndex === null) return;
+      this.toggleAnswer(this.hoveredIndex);
     },
     updateDefaultSetting() {
       this.defaultShowAnswer = !this.defaultShowAnswer

--- a/src/utils/questionType.ts
+++ b/src/utils/questionType.ts
@@ -1,0 +1,20 @@
+export type QuestionType = 'rightWrong' | 'singleChoice' | 'multipleChoice' | 'fillingBlank'
+
+export function getQuestionType(question: {
+  option?: string[] | string
+  answer?: string
+}): QuestionType | null {
+  const { option, answer } = question
+  if (!option || option.length === 0) return 'fillingBlank'
+  if (option.length === 2) return 'rightWrong'
+  if (answer && answer.length === 1) return 'singleChoice'
+  if (answer && answer.length > 1) return 'multipleChoice'
+  return null
+}
+
+export const TYPE_LABEL: Record<QuestionType, string> = {
+  rightWrong: '判断',
+  singleChoice: '单选',
+  multipleChoice: '多选',
+  fillingBlank: '填空'
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -8,5 +8,12 @@ export default defineConfig({
     alias: {
       '@': path.resolve(__dirname, 'src')
     }
+  },
+  css: {
+    preprocessorOptions: {
+      scss: {
+        api: 'modern-compiler'
+      }
+    }
   }
 })


### PR DESCRIPTION
## 键盘快捷键

普通模式两组快捷键：
双手方案 `q`切换鼠标悬浮题目的答案显示/隐藏
右手方案 `0`切换当前题目答案显示状态，`-`滚动到上一题，`=`滚动到下一题
*以页面顶端的题目作为「当前题」，鼠标滚动也会同步题号*

## 单题组件 & 题型util
- 新增 `QuestionItem.vue`，`questionCard.vue` 改为调用该组件
- 新增 `utils/questionType.ts`判断题型，并提供 `TYPE_LABEL` 中文标签

## 构建配置
1. `jsconfig.json`：`target` → `esnext`，`moduleResolution` → `bundler`，
  修正 `@/*` 路径，使 IDE 解析与 Vite 一致
2. `vite.config.js`：SCSS 启用 `modern-compiler`

参考文档
[1.1](https://www.typescriptlang.org/tsconfig#compilerOptions), [1.2](https://www.typescriptlang.org/docs/handbook/modules/guides/choosing-compiler-options.html), [1.3](https://www.typescriptlang.org/tsconfig/#baseUrl)
[2.1](https://vite.dev/config/shared-options.html#css-preprocessoroptions), [2.2](https://sass-lang.com/documentation/breaking-changes/legacy-js-api/#bundlers)

## 已完成测试
- `q` / `0` / `-` / `=` 正常
- 搜索/浏览器快捷键不冲突
-  `QuestionItem.vue` 渲染

## 实现备注
  - 平滑滚动期间用 suppress 标记保留乐观题号，支持快速连按翻题
  - 用题卡 `bottom > 顶端线` 判定当前题，规避 `scroll-margin-top`导致的 off-by-one
  -  输入框/搜索框聚焦时不触发，保留浏览器原生快捷键